### PR TITLE
remove codesponsor

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -76,7 +76,7 @@ If you enjoy node-twitter, you can support the development here. https://gratipa
 [GPL-3.0](https://github.com/vinitkumar/node-twitter/blob/master/License)
 
 ## Sponsors
-<a target='_blank' rel='nofollow' href='https://app.codesponsor.io/link/uyhQ2YHmpDTZbNRraFXJEvTa/vinitkumar/node-twitter'><img alt='Sponsor' width='888' height='68' src='https://app.codesponsor.io/embed/uyhQ2YHmpDTZbNRraFXJEvTa/vinitkumar/node-twitter.svg' /></a>
+
 
 ## Important
 


### PR DESCRIPTION
Pull request automatically sent by knewzen <https://github.com/knewzen>. Because Code Sponsor is shutting down on December 8